### PR TITLE
Add Parker weighting for short scans

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Sinograms"
 uuid = "02a14def-c6e6-4ab0-b2df-0ab64bc8cdd7"
 authors = ["fessler <fessler@umich.edu>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -10,7 +10,7 @@ LazyGrids = "7031d0ef-c40d-4431-b2f8-61a8d2f650db"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-FFTW = "1.4.5"
+FFTW = "1.4.5, 1.5"
 ImageGeoms = "0.9, 0.10"
 LazyGrids = "0.4, 0.5"
 Requires = "1.3"

--- a/docs/lit/examples/04-fan-arc.jl
+++ b/docs/lit/examples/04-fan-arc.jl
@@ -79,7 +79,7 @@ prompt()
 μ = 0.01 / mm # typical linear attenuation coefficient
 ob = shepp_logan(SheppLogan(); fovs = fovs(ig), u = (1, 1, μ))
 
-# Flat fan-beam sinogram for Shepp-Logan phantom:
+# Arc fan-beam sinogram for Shepp-Logan phantom:
 sino = radon(rays(sg), ob)
 jim(sg.r, sg.ad, sino; title="Shepp-Logan sinogram", xlabel="r", ylabel="ϕ")
 

--- a/docs/lit/examples/06-fan-short.jl
+++ b/docs/lit/examples/06-fan-short.jl
@@ -1,0 +1,115 @@
+#=
+# [Fan-beam tomography: arc detector](@id 06-fan-short)
+
+This page describes fan-beam tomographic image reconstruction
+using the Julia package
+[`Sinograms.jl`](https://github.com/JuliaImageRecon/Sinograms.jl)
+for a "short" scan
+where the rotation (`orbit`) is 180° plus the fan angle.
+This case requires
+[Parker weighting](http://doi.org/10.1118/1.595078).
+
+This page focuses on fan-beam with an "arc" detector,
+i.e., 3rd-generation CT systems
+where the detector is an arc
+having a focal point
+at the X-ray source.
+This geometry is popular
+in part because it facilitates
+anti-scatter grids.
+
+This page was generated from a single Julia file:
+[06-fan-short.jl](@__REPO_ROOT_URL__/06-fan-short.jl).
+=#
+
+#md # In any such Julia documentation,
+#md # you can access the source code
+#md # using the "Edit on GitHub" link in the top right.
+
+#md # The corresponding notebook can be viewed in
+#md # [nbviewer](http://nbviewer.jupyter.org/) here:
+#md # [`06-fan-short.ipynb`](@__NBVIEWER_ROOT_URL__/06-fan-short.ipynb),
+#md # and opened in [binder](https://mybinder.org/) here:
+#md # [`06-fan-short.ipynb`](@__BINDER_ROOT_URL__/06-fan-short.ipynb).
+
+
+# ### Setup
+
+# Packages needed here.
+
+using Plots: plot, gui # these 2 must precede Sinograms for Requires to work!
+using Unitful: mm
+using Sinograms: SinoFanArc, rays, plan_fbp, fbp, sino_geom_plot!
+using ImageGeoms: ImageGeom, fovs, MaskCircle
+using ImagePhantoms: SheppLogan, shepp_logan, radon, phantom
+using MIRTjim: jim, prompt
+
+
+# The following line is helpful when running this example.jl file as a script;
+# this way it will prompt user to hit a key after each figure is displayed.
+
+isinteractive() ? jim(:prompt, true) : prompt(:draw);
+
+
+#=
+### Fan-beam sinogram of Shepp-Logan phantom
+
+For illustration,
+we start by synthesizing
+a fan-beam sinogram
+of the Shepp-Logan phantom.
+
+For completeness,
+we use units (from Unitful),
+but units are optional.
+=#
+
+# Use `ImageGeom` to define the image geometry.
+ig = ImageGeom(MaskCircle(); dims=(128,126), deltas = (2mm,2mm) )
+
+# Use `SinoFanArc` to define the sinogram geometry,
+# with the `:short` option for `orbit` to make a short scan.
+sg = SinoFanArc( ;
+    orbit = :short,
+    nb = 130, d = 3.2mm, na = 100, dsd = 400mm, dod = 140mm,
+)
+
+# Examine the geometry to verify the FOV:
+jim(axes(ig), ig.mask; prompt=false)
+sino_geom_plot!(sg, ig)
+
+#
+prompt()
+
+# Ellipse parameters for Shepp-Logan phantom:
+μ = 0.01 / mm # typical linear attenuation coefficient
+ob = shepp_logan(SheppLogan(); fovs = fovs(ig), u = (1, 1, μ))
+
+# Short arc fan-beam sinogram for Shepp-Logan phantom:
+sino = radon(rays(sg), ob)
+jim(sg.r, sg.ad, sino; title="Shepp-Logan 'short' sinogram",
+    xlabel="r", ylabel="ϕ")
+
+
+#=
+## Image reconstruction via FBP
+Here we start with a "plan",
+which would save work if we were reconstructing many images.
+=#
+
+plan = plan_fbp(sg, ig)
+
+# Examine Parker weights
+jim(sg.r, sg.ad, plan.parker_weight; title = "Parker weights",
+    xlabel="r", ylabel="ϕ")
+
+# Finally perform FBP
+fbp_image, sino_filt = fbp(plan, sino);
+
+# A narrow color window is needed to see the soft tissue structures:
+clim = (0.9, 1.1) .* μ
+jim(axes(ig), fbp_image, "FBP image for 'short' arc case"; clim)
+
+# For comparison, here is the ideal phantom image
+true_image = phantom(axes(ig)..., ob, 2)
+jim(axes(ig)..., true_image, "True phantom image"; clim)

--- a/docs/lit/examples/06-fan-short.jl
+++ b/docs/lit/examples/06-fan-short.jl
@@ -69,8 +69,7 @@ ig = ImageGeom(MaskCircle(); dims=(128,126), deltas = (2mm,2mm) )
 
 # Use `SinoFanArc` to define the sinogram geometry,
 # with the `:short` option for `orbit` to make a short scan.
-sg = SinoFanArc( ;
-    orbit = :short,
+sg = SinoFanArc( :short, ;
     nb = 130, d = 3.2mm, na = 100, dsd = 400mm, dod = 140mm,
 )
 

--- a/src/fbp-axis.jl
+++ b/src/fbp-axis.jl
@@ -61,7 +61,7 @@ function fbp!(
 end
 
 
-function sino_geom(sino::AxisMatrix ; geo::DataType = SinoPar, kwargs...)
+function sino_geom(sino::AxisMatrix ; geo::Type{<:RayGeom} = SinoPar, kwargs...)
     geo( ;
         nb = size(sino,1),
         na = size(sino,2),

--- a/src/fbp/window.jl
+++ b/src/fbp/window.jl
@@ -69,7 +69,7 @@ end
 function fbp_window(
     w::Window{S},
     N::Int ;
-    T::DataType = eltype(w.shape.v),
+    T::Type{<:Number} = eltype(w.shape.v),
 ) where {S <: WindowVect}
     N == length(w.shape.v) || throw("N mismatch")
     return fftshift(T.(w.shape.v))

--- a/src/fbp2/back-fan.jl
+++ b/src/fbp2/back-fan.jl
@@ -154,7 +154,7 @@ It assumes the angles are equally spaced over `[0,π)`.
 
 # option
 - `ia_skip::Int` default 1
-- `T::DataType` usually same as `eltype(sino)`
+- `T::Type{<:Number}` usually same as `eltype(sino)`
 
 # out
 - `image::Matrix` `(nx, ny)`
@@ -172,7 +172,7 @@ function fbp_back_fan(
     yc::AbstractArray{Tc},
     mask::AbstractMatrix{Bool} ;
     ia_skip::Int = 1,
-    T::DataType = eltype(oneunit(Ts) *
+    T::Type{<:Number} = eltype(oneunit(Ts) *
         (oneunit(To) * oneunit(Tc) / oneunit(Tds) + oneunit(Toffset))),
 ) where {Ts <: Number, To <: RealU, Tds <: RealU, Toffset <: Real, Tc <: RealU}
 
@@ -275,7 +275,7 @@ It assumes the angles are equally spaced over `[0,π)`.
 - `x,y::Real` pixel center location, normalized by ray spacing
 
 # option
-- `T::DataType` typically same as `eltype(sino)`
+- `T::Type{<:Number}` typically same as `eltype(sino)`
 
 # out
 - Returns a scalar of type `T`.
@@ -291,7 +291,7 @@ function fbp_back_fan_xy(
     wb::Tb, # (nb+1)/2 + offset
     x_ds::Tx, # xc / ds
     y_ds::Tx ;
-    T::DataType = eltype(oneunit(Ts) * one(To) * one(Tb) * one(Tx)),
+    T::Type{<:Number} = eltype(oneunit(Ts) * one(To) * one(Tb) * one(Tx)),
 ) where {Ts <: Number, To <: Real, Tb <: Real, Tx <: Real}
 
     nb = size(sino,1)

--- a/src/fbp2/back-par.jl
+++ b/src/fbp2/back-par.jl
@@ -153,7 +153,7 @@ It assumes the angles are equally spaced over `[0,π)`.
 
 # option
 - `ia_skip::Int` default 1
-- `T::DataType` usually same as `eltype(sino)`
+- `T::Type{<:Number}` usually same as `eltype(sino)`
 
 # out
 - `image::Matrix` `(nx, ny)`
@@ -269,7 +269,7 @@ It assumes the angles are equally spaced over `[0,π)`.
 - `x,y::Real` pixel center location, normalized by ray spacing
 
 # option
-- `T::DataType` typically same as `eltype(sino)`
+- `T::Type{<:Number}` typically same as `eltype(sino)`
 
 # out
 - Returns a scalar of type `T`.
@@ -281,7 +281,7 @@ function fbp_back_par_xy(
     wb::Tb, # (nb+1)/2 + offset
     x_ds::Tx, # xc / ds
     y_ds::Tx ;
-    T::DataType = eltype(oneunit(Ts) * one(To) * one(Tb) * one(Tx)),
+    T::Type{<:Number} = eltype(oneunit(Ts) * one(To) * one(Tb) * one(Tx)),
 ) where {Ts <: Number, To <: Real, Tb <: Real, Tx <: Real}
 
     nb = size(sino,1)

--- a/src/fbp2/fbp.jl
+++ b/src/fbp2/fbp.jl
@@ -62,12 +62,14 @@ function fbp(
     ig::ImageGeom,
     sino::AbstractMatrix{<:Number},
     filter::AbstractVector{<:Number},
-    parker_weight::AbstractVector{<:Number} = ones(size(sino,2)),
+    parker_weight::AbstractArray{<:Number} = ones(size(sino,2)),
 )
-    dims(sg) == size(sino) || throw("bad sino size")
-    length(parker_weight) == sg.na || throw("bad parker size")
+    dims(sg) == size(sino) || error("bad sino size")
+    parker = length(parker_weight) == sg.na ? parker_weight' :
+        size(parker_weight) == dims(sg) ? parker_weight :
+        error("bad parker size $(size(parker_weight))")
 
-    sino_filt = sino .* parker_weight'
+    sino_filt = sino .* parker
     sino_filt = fbp_sino_filter(sino_filt, filter)
 
     image = fbp_back(sg, ig, sino_filt)

--- a/src/fbp2/parker.jl
+++ b/src/fbp2/parker.jl
@@ -1,58 +1,113 @@
 # fbp2/parker.jl
-# Parker weighting for FBP reconstruction
+# Parker weighting for FBP reconstruction http://doi.org/10.1118/1.595078
 
 export parker_weight
 # using Sinograms: SinoGeom, SinoPar, SinoFan, SinoMoj
+using LazyGrids: ndgrid
+
+
+# parallel-beam case: returns a Vector
+function parker_weight_par(
+    orbit::RealU,
+    ad::AbstractVector{<:RealU}, # angles in degrees: sg.ad - sg.orbit_start
+    ;
+    T::Type{<:Real} = Float32,
+)
+
+    wt = ones(T, length(ad))
+
+    if (orbit ÷ 180) * 180 == orbit
+        return wt # no weighting needed
+    end
+
+    if orbit < 180
+        @warn("orbit $orbit < 180")
+        return wt # nonuniform weighting would not help
+    end
+
+    orbit > 360 && error("only 180 ≤ |orbit| ≤ 360 supported for Parker weighting")
+    extra = orbit - 180 # extra beyond 180
+
+    ad = abs.(ad)
+    ii = ad .< extra
+    @. wt[ii] = abs2(sin(ad[ii] / extra * π/2))
+    ii = ad .≥ 180
+    @. wt[ii] = abs2(sin((orbit - ad[ii]) / extra * π/2))
+    wt .*= orbit / 180 # because of the back-projector normalization
+    return wt
+end
 
 
 """
     parker_weight(sg::SinoGeom ; T = Float32)
 Compute Parker weighting for non-360° orbits.
-Returns `Vector{T}` of length `sg.na`.
+Returns `Vector{T}` of length `sg.na` for `SinoPar`.
+Returns `Matrix{T}` of size `dims(sg)` for `SinoFan`.
 """
-function parker_weight(sg::SinoPar ; T::DataType = Float32)::Vector{T}
-    orbit = abs(sg.orbit)
-    na = sg.na
-    ad = @. abs(sg.ad - sg.orbit_start)
+parker_weight(sg::SinoPar ; T::Type{<:Real} = Float32)::Vector{T} =
+    parker_weight_par(sg.orbit, sg.ad .- sg.orbit_start ; T)
 
-    wt = ones(T, na)
 
-    if (sg.orbit ÷ 180) * 180 == orbit
-        return wt
-    end
+function parker_weight_fan(
+    nb::Int,
+    na::Int,
+    orbit::RealU,
+    orbit_short::RealU,
+    ar::AbstractVector{<:RealU}, # angles in radians
+    gam::AbstractVector{<:RealU},
+    gamma_max::RealU, # half of fan angle
+    ;
+    T::Type{<:Real} = Float32,
+)
 
-    if orbit < 180
-        @warn("orbit $orbit < 180")
-        return wt
-    end
+    na == length(ar) || error("na bug")
+    orbit < orbit_short - eps() &&
+        @warn("orbit $orbit is less than a short scan $orbit_short")
 
-    orbit > 360 && throw("only 180 ≤ |orbit| ≤ 360 supported for Parker weighting")
-    extra = orbit - 180 # extra beyond 180
+    orbit > orbit_short + rad2deg(ar[2] - ar[1]) &&
+        @warn("orbit $orbit exeeds short scan $orbit_short by %g views")
+    #   (orbit - orbit_short) / rad2deg(ar[2] - ar[1]))
 
-    ii = ad .< extra
-    wt[ii] = @. abs2(sin(ad[ii] / extra * π/2))
-    ii = ad .≥ 180
-    wt[ii] = @. abs2(sin((orbit - ad[ii]) / extra * π/2))
-    wt *= orbit / 180 # trick because of the back-projector normalization
+    bet = ar .- ar[1] # trick: force 0 start, so this ignores orbit_start!
+    (gg, bb) = ndgrid(gam, bet)
+
+    fun = (x) -> sin(π/2 * x)^2 # smooth out [0,1] ramp
+    #=
+    todo: We could use integrals of this function
+    over the tiny angular range of each projection view,
+    so that the sum over beta of these functions is a constant.
+    =#
+
+    wt = zeros(T,nb,na) # any extra views will get 0 weight
+    ii = @. bb < 2 * (gamma_max .- gg) # 0 <= bb not needed
+    tmp = bb[ii] ./ (2 * (gamma_max .- gg[ii]))
+    @. wt[ii] = fun(tmp)
+
+    ii = @. (2 * (gamma_max - gg) ≤ bb) & (bb < π - 2 * gg)
+    wt[ii] .= 1
+
+    ii = @. (π - 2 * gg < bb) & (bb ≤ π + 2 * gamma_max)
+    tmp = @. (π + 2*gamma_max - bb[ii]) / (2 * (gamma_max + gg[ii]))
+    @. wt[ii] = fun(tmp)
+
+    wt .*= orbit / 180 # because of the back-projector normalization
     return wt
 end
 
 
-function parker_weight_fan(na::Int, orbit::RealU; T::DataType = Float32)
-    wt = ones(T, na)
-    if (orbit ÷ 360) * 360 == orbit
+function parker_weight(sg::SinoFan; T::Type{<:Real} = Float32)::Matrix{T}
+    wt = ones(T, dims(sg))
+    if (sg.orbit ÷ 360) * 360 == sg.orbit
         return wt
     end
-    @warn("todo: short-scan fan-beam Parker weighting not done")
-    wt = zeros(T, na)
-    return wt
+    return parker_weight_fan(
+        sg.nb, sg.na, sg.orbit, sg.orbit_short,
+        sg.ar, sg.gamma, sg.gamma_max; T
+    )
 end
 
-parker_weight(sg::SinoFan; T::DataType = Float32)::Vector{T} =
-    parker_weight_fan(sg.na, sg.orbit; T)
 
-
-function parker_weight(sg::SinoMoj ; T::DataType = Float32)::Vector{T}
+function parker_weight(sg::SinoMoj ; T::Type{<:Real} = Float32)::Vector{T}
     orbit = abs(sg.orbit)
     na = sg.na
     ((sg.orbit ÷ 180) * 180 == orbit) ||

--- a/src/fbp2/plan2.jl
+++ b/src/fbp2/plan2.jl
@@ -30,12 +30,12 @@ struct FBPNormalPlan{
     S <: SinoGeom,
     I <: ImageGeom,
     H <: AbstractVector{<:RealU},
-    P <: AbstractVector{<:Real},
+    P <: Any,
 } <: FBPplan
     sg::S
     ig::I
     filter::H # frequency response Hk of apodized ramp filter, length npad
-    parker_weight::P
+    parker_weight::P # typically a 1D or 2D array of nonnegative reals
 #   moj::Moj # todo
 
 #=
@@ -102,7 +102,7 @@ call `fbp` with the `plan`
 - `window::Window` e.g., `Window(Hamming(), 0.8)`; default `Window()`
 - `npad::Int` # of radial bins after padding; default `nextpow(2, sg.nb + 1)`
 - `decon1::Bool` deconvolve interpolator effect? (default `true`)
--`T::DataType` type of sino elements (default `Float32`)
+- `T::Type{<:Number}` type of `sino` elements (default `Float32`)
 
 # out
 - `plan::FBPplan` initialized plan
@@ -115,7 +115,7 @@ function plan_fbp(
     window::Window = Window(),
     npad::Int = nextpow(2, sg.nb + 1),
     decon1::Bool = true,
-    T::DataType = Float32,
+    T::Type{<:Number} = Float32,
 #   nthread::Int = Threads.nthreads(),
 )
 
@@ -149,7 +149,7 @@ function plan_fbp_normal(
 #   npad::Int,
 #   window::Window,
     filter::AbstractVector{<:RealU},
-#   T::DataType = Float32,
+#   T::Type{<:Number} = Float32,
 )
     weight = parker_weight(sg)
 
@@ -164,7 +164,7 @@ function plan_fbp_normal(
     sg::SinoMoj,
     ig::ImageGeom ;
     window::Window = Window(),
-    T::DataType = Float32,
+    T::Type{<:Number} = Float32,
 )
     weight = ones(T, sg.nb, sg.na)
     if sg.dx == abs(ig.dx)
@@ -186,6 +186,6 @@ function Base.show(io::IO, ::MIME"text/plain", p::FBPNormalPlan{S,I,H,P}) where 
     println(io, "FBPNormalPlan{S,I,H,P} with")
     println(io, " S = $S")
     println(io, " I = $I")
-    println(io, " H = $H with extrema $(extrema(p.filter))")
-    println(io, " P = $P with extrema $(extrema(p.parker_weight))")
+    println(io, " H = $H with extrema ", extrema(p.filter))
+    println(io, " P = $P ", size(p.parker_weight), " with extrema ", extrema(p.parker_weight))
 end

--- a/src/fbp3/cbct-back.jl
+++ b/src/fbp3/cbct-back.jl
@@ -66,7 +66,7 @@ function cbct_back_fan(
     zc::AbstractVector{<:Tc},
     mask::AbstractArray{Bool,3} ;
     ia_skip::Int = 1,
-    T::DataType = eltype(oneunit(Ts)
+    T::Type{<:Number} = eltype(oneunit(Ts)
         * (oneunit(To) * oneunit(Tc) / oneunit(Tds) + oneunit(Toffset))),
 )::Array{T,3} where {
     Ts <: Number,
@@ -169,7 +169,7 @@ function cbct_back_fan_voxel(
     x_ds::Tx,
     y_ds::Tx,
     z_ds::Tx ;
-    T::DataType = eltype(oneunit(Tp) * one(To) * one(Tw) * one(Tx)),
+    T::Type{<:Number} = eltype(oneunit(Tp) * one(To) * one(Tw) * one(Tx)),
 ) where {Tp <: Number, To <: Real, Tw <: Real, Tx <: Real}
 
     voxel = zero(Tp)

--- a/src/geom/common.jl
+++ b/src/geom/common.jl
@@ -23,9 +23,9 @@ Base.propertynames(st::RayGeom) =
     (fieldnames(typeof(st))..., map(x -> x[1], _props(st))...)
 
 
-Base.ones(T::DataType, st::RayGeom) = ones(T, dims(st))
+Base.ones(T::Type{<:Number}, st::RayGeom) = ones(T, dims(st))
 Base.ones(st::RayGeom) = ones(Float32, st)
-Base.zeros(T::DataType, st::RayGeom) = zeros(T, dims(st))
+Base.zeros(T::Type{<:Number}, st::RayGeom) = zeros(T, dims(st))
 Base.zeros(st::RayGeom) = zeros(Float32, st)
 
 angles(st::RayGeom{Td,To}) where {Td,To} =
@@ -107,7 +107,7 @@ Projection views with a single non-zero ray value
 at position `pos` (default: middle).
 """
 function _geom_unitv(
-    T::DataType,
+    T::Type{<:Number},
     st::RayGeom,
     pos::Tuple = dims(st) .÷ 2 .+ 1,
 )

--- a/src/geom/ct-geom.jl
+++ b/src/geom/ct-geom.jl
@@ -19,14 +19,14 @@ ct_geom_wt(st::CtGeom) = ((st.nt-1)//2 + st.offset_t)::Toffset
 #ct_geom_s(st::CtGeom) = st.ds * ((0:st.ns-1) .- st.ws) # can't infer!?
 function ct_geom_s(
     st::CtGeom{Td} ;
-    T::DataType = eltype(oneunit(Td) * one(Toffset)),
+    T::Type{<:Number} = eltype(oneunit(Td) * one(Toffset)),
 )::LinRange{T,Int} where {Td}
     return _lin_range(st.ds, st.ws, st.ns)
 end
 
 function ct_geom_t(
     st::CtGeom{Td} ;
-    T::DataType = eltype(oneunit(Td) * one(Toffset)),
+    T::Type{<:Number} = eltype(oneunit(Td) * one(Toffset)),
 )::LinRange{T,Int} where {Td}
     return _lin_range(st.dt, st.wt, st.nt)
 end

--- a/src/geom/sino-geom.jl
+++ b/src/geom/sino-geom.jl
@@ -18,7 +18,7 @@ sino_w(sg::SinoGeom) = Toffset((sg.nb-1)/2 + sg.offset)::Toffset
 #sino_s(sg::SinoGeom) = _lin_range(sg.d, sg.w, sg.nb) # can't infer!?
 function sino_s(
     st::SinoGeom{Td} ;
-    T::DataType = eltype(oneunit(Td) * one(Toffset)),
+    T::Type{<:Number} = eltype(oneunit(Td) * one(Toffset)),
 )::LinRange{T,Int} where {Td}
     return _lin_range(st.d, st.w, st.nb)
 end

--- a/src/geom/type2.jl
+++ b/src/geom/type2.jl
@@ -236,12 +236,17 @@ end
 """
     SinoFanArc( ; nb d offset na orbit orbit_start
         source_offset, dsd = 4 * nb * d, dod = nb * d)
+    SinoFanArc(:short ; nb d offset na orbit_start
+        source_offset, dsd = 4 * nb * d, dod = nb * d)
 
 Constructor with named keywords.
 See `?SinoGeom` for documentation.
 
 * `d`, `source_offset`, `dsd`, `dod`
   must all have the same units.
+
+* Use `:short` argument to specify a short scan,
+  in which case `na` will be scaled down proportionally as well.
 
 ```jldoctest
 julia> SinoFanArc()
@@ -274,6 +279,37 @@ function SinoFanArc( ;
     return SinoFanArc(nb, Td(d), Toffset(offset),
         na, To(orbit), To(orbit_start),
         Td(source_offset), Td(dsd), Td(dod),
+    )
+end
+
+
+# :short case
+function SinoFanArc(orbit::Symbol ;
+    nb::Int = 128,
+    d::RealU = 1,
+    offset::Real = 0,
+    na::Int = 2 * floor(Int, nb * π/2 / 2),
+    orbit_start::RealU = 0f0,
+    source_offset::RealU = zero(eltype(d)),
+    dsd::RealU = 4 * nb * d,
+    dod::RealU = nb * d,
+)
+
+    orbit == :short || error("bad orbit $orbit")
+
+    Td = _promoter(d, source_offset, dsd, dod)
+    To = typeof(1f0 * orbit_start)
+    tmp = SinoFanArc(
+        nb, Td(d), Toffset(offset),
+        na, To(360), To(orbit_start),
+        Td(source_offset), Td(dsd), Td(dod),
+    )
+    na = ceil(Int, na * tmp.orbit_short / 360)
+    orbit = To(tmp.orbit_short)
+
+    return SinoFanArc( ;
+        nb, na, d, offset, orbit, orbit_start,
+        source_offset, dsd, dod,
     )
 end
 

--- a/src/geom/util.jl
+++ b/src/geom/util.jl
@@ -46,7 +46,7 @@ reshaper(x::AbstractArray, dim::Dims) =
 # seems to be needed to help with type inference
 function _lin_range(
     d::Td, w::Toffset, n::Int ;
-    T::DataType = eltype(oneunit(Td) * one(Toffset)),
+    T::Type{<:Number} = eltype(oneunit(Td) * one(Toffset)),
 )::LinRange{T,Int} where {Td <: RealU}
     return d * LinRange(-w, n - 1 - w, n)
 end

--- a/test/fbp2/parker.jl
+++ b/test/fbp2/parker.jl
@@ -3,37 +3,49 @@ test/fbp2/parker.jl
 =#
 
 using Sinograms: SinoPar, SinoFanArc, SinoMoj
-using Sinograms: parker_weight, parker_weight_fan
+using Sinograms: parker_weight, parker_weight_fan, parker_weight_par, dims
 using Test: @test, @test_throws, @testset, @inferred
 
 
-@testset "parker" begin
-
-    pw = @inferred parker_weight_fan(10, 360.)
-    pw = @inferred parker_weight_fan(10, 99.)
-    @test pw == zeros(10) # todo: until short-scan done
-
-    geoms = (SinoPar, SinoFanArc, SinoMoj)
-    for geom in (geoms)
-        sg = geom()
-        pw = @inferred parker_weight(sg)
-        @test pw isa Vector{Float32}
-        @test pw[1] == 1
-    end
+@testset "parker-par" begin
+    sg = SinoPar()
+    pw = @inferred parker_weight_par(sg.orbit, sg.ad)
+    @test pw == ones(sg.na)
+    @test pw isa Vector{Float32}
 
     sg = SinoPar( ; orbit = 90)
-    pw = @inferred parker_weight(sg)
+    pw = @inferred parker_weight(sg) # warns
 
     sg = SinoPar( ; orbit = 361)
-    @test_throws String parker_weight(sg)
+    @test_throws ErrorException parker_weight(sg)
 
     sg = SinoPar( ; orbit = 270)
     pw = @inferred parker_weight(sg)
     @test pw[1] == 0 # todo: suboptimal?
     @test sum(pw)/length(pw) ≈ 1
 
-    sg = SinoFanArc( ; orbit = 90)
-#   @test_throws String
+    sg = SinoMoj()
     pw = @inferred parker_weight(sg)
-    @test pw == zeros(sg.na) # todo: until short-scan done
+    @test pw isa Vector{Float32}
+    @test pw[1] == 1
+end
+
+
+@testset "parker-fan" begin
+    sg = SinoFanArc(Val(:ge1), orbit=:short)
+    pw = @inferred parker_weight_fan(sg.nb, sg.na, sg.orbit, sg.orbit_short,
+        sg.ar, sg.gamma, sg.gamma_max)
+    @test pw isa Matrix{Float32}
+    tmp = sum(pw; dims=2)
+    tmp = 1 - minimum(tmp)/maximum(tmp)
+    @test abs(tmp) < 0.002 # should be nearly uniform
+
+    sg = SinoFanArc(; orbit=360)
+    pw = @inferred parker_weight(sg)
+    @test pw isa Matrix{Float32}
+    @test pw == ones(dims(sg))
+
+    sg = SinoFanArc( ; orbit = 90)
+    pw = @inferred parker_weight(sg) # warns
+    @test pw isa Matrix{Float32}
 end

--- a/test/geom/sino-geom.jl
+++ b/test/geom/sino-geom.jl
@@ -46,6 +46,9 @@ end
 
     st = @inferred ge1( ; unit = oneunit(d), orbit=:short)
     @test st isa SinoFanArc
+
+    st = SinoFanArc(:short) # @NOTinferred
+    @test st isa SinoFanArc
 end
 
 


### PR DESCRIPTION
Hopefully will address #39.
Also using `Type{<:Number}` instead of `DataType` because somewhere the manual recommended it.